### PR TITLE
More suitable firmware for DW1820A

### DIFF
--- a/BrcmPatchRAM/BrcmPatchRAM2-Info.plist
+++ b/BrcmPatchRAM/BrcmPatchRAM2-Info.plist
@@ -1083,7 +1083,7 @@
 			<key>DisplayName</key>
 			<string>Dell Wireless 1820A Bluetooth 4.1 LE</string>
 			<key>FirmwareKey</key>
-			<string>BCM4350C5_003.006.007.0095.1703_v5799</string>
+			<string>BCM20703A1_001.001.005.0214.0422_v4518</string>
 			<key>IOClass</key>
 			<string>BrcmPatchRAM2</string>
 			<key>IOMatchCategory</key>


### PR DESCRIPTION
Hey,

Current firmware for DW1820A in BrcmPatchRAM2 is not working correctly. So, I have dig up a bit and I have seen that DW1820A have the same Bluetooth chip than DW1830. I have made the changes to load the same firmware. I have tested it and it's working wonderfully now.